### PR TITLE
Enable lexical binding

### DIFF
--- a/evil-markdown.el
+++ b/evil-markdown.el
@@ -1,4 +1,4 @@
-;;; evil-markdown.el --- evil keybindings for markdown-mode
+;;; evil-markdown.el --- evil keybindings for markdown-mode -*- lexical-binding: t; -*-
 
 ;; Maintainer: Somelauw
 ;; URL: https://github.com/Somelauw/evil-markdown.git


### PR DESCRIPTION
Hi. I have inspected your codebase and found no code which presents a problem with enabling lexical-binding. One day Emacs will enable lexical binding by default so it's better merge this earlier to reduce the risk of a mass config breakage event.